### PR TITLE
Check for mouse button not being left click in link component

### DIFF
--- a/app/components/component-link.jsx
+++ b/app/components/component-link.jsx
@@ -14,7 +14,7 @@ module.exports = React.createClass({
 
     onClick: function(e) {
         // If trying to open a new window, fall back
-        if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey || e.button === 2) {
+        if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey || e.button !== 0) {
             return;
         }
 


### PR DESCRIPTION
Currently, middle clicking navigates in the same window.

Checking for the mouse button not being a left click should fix this.
