### PR TITLE
Fix issue where large images overflow the readme section

### DIFF
--- a/public/less/_readme.less
+++ b/public/less/_readme.less
@@ -13,4 +13,8 @@
         line-height: 1em;
     }
 
+    img {
+        max-width: 100%;
+    }
+
 }


### PR DESCRIPTION
You can see  the issue here: http://react-components.com/component/react-theatre though that particular image won't be that large for much longer.